### PR TITLE
adding ability to set selected toggle for dropdowns

### DIFF
--- a/src/ofxUIDropDownList.cpp
+++ b/src/ofxUIDropDownList.cpp
@@ -482,3 +482,17 @@ bool ofxUIDropDownList::isOpen()
 {
     return *value;
 }
+
+void ofxUIDropDownList::setSingleSelected(int index){
+    
+    vector<ofxUILabelToggle*> toggles = getToggles();
+    if(index < toggles.size()){
+        selected.clear();
+        ofxUILabelToggle *lt = toggles.at(index);
+        selected.push_back(lt);
+        setShowCurrentSelected(true);
+    }else{
+        ofLogWarning("index for ufxUIDropDownList::setSingleSelected is out of range");
+    }
+    
+}

--- a/src/ofxUIDropDownList.h
+++ b/src/ofxUIDropDownList.h
@@ -65,6 +65,9 @@ public:
     virtual void setModal(bool _modal);      
     bool isOpen();
     
+    //sets the selected toggle for a dropdown and displays it; does not allow multiple selected options
+    void setSingleSelected(int index);
+    
 protected:
     bool autoSize; 
     bool autoClose;


### PR DESCRIPTION
Using ofxUI is fantastic (so first off, thx!) but I was kinda surprised to find that (unless I'm missing smthg) there wasn't a way to programmatically select an specific toggle from a dropdown.  This is useful for when you have to dropdowns, and the value of the second one should change based on what the user select for the first one.

Or, if you loading saved settings from XML and want to populate the value of the dropdown.

This doesn't yet take into account dropdowns with multiple selections.