### PR TITLE
Add getRadio() to match other get methods

### DIFF
--- a/src/ofxUIEventArgs.cpp
+++ b/src/ofxUIEventArgs.cpp
@@ -40,6 +40,11 @@ ofxUIButton *ofxUIEventArgs::getButton()
     return (ofxUIButton *) widget;
 }
 
+ofxUIRadio *ofxUIEventArgs::getRadio()
+{
+    return (ofxUIRadio *) widget;
+}
+
 ofxUIToggle *ofxUIEventArgs::getToggle()
 {
     return (ofxUIToggle *) widget;

--- a/src/ofxUIEventArgs.h
+++ b/src/ofxUIEventArgs.h
@@ -28,6 +28,7 @@
 #include "ofxUISlider.h"
 #include "ofxUIWidget.h"
 #include "ofxUIButton.h"
+#include "ofxUIRadio.h"
 #include "ofxUIToggle.h"
 
 class ofxUICanvas;
@@ -38,6 +39,7 @@ public:
 	ofxUIEventArgs();
     ofxUIEventArgs(ofxUIWidget *_widget);
     ofxUIButton *getButton();
+    ofxUIRadio  *getRadio();
     ofxUIToggle *getToggle();
     ofxUISlider *getSlider();
     ofxUICanvas *getCanvasParent();


### PR DESCRIPTION
The examples use e->getSlider(), e->getButton() etc. Added getRadio() to work in a similar fashion,
to match the other ofxUIEventArgs methods.